### PR TITLE
Improve chart palette and filter VB-Custom from stats

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -40,6 +40,10 @@ a:hover{text-decoration:underline}
 .card{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:16px;box-shadow:var(--shadow)}
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px}
 .project{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:16px;position:relative}
+.project-content{display:flex;gap:16px;align-items:flex-start}
+.project-info{flex:1;min-width:0}
+.project-chart{width:160px;display:flex;flex-direction:column;align-items:center;justify-content:center}
+.project-chart canvas{max-width:140px}
 .project h4{margin:0 0 6px}
 .tags{display:flex;flex-wrap:wrap;gap:6px;margin:8px 0}
 .tag-chip{font-size:12px;padding:4px 8px;border-radius:999px;border:1px solid var(--border);color:var(--gray-light)}
@@ -50,3 +54,30 @@ a:hover{text-decoration:underline}
 .site-footer{border-top:1px solid var(--border);background:#0e1014;padding:24px}
 .site-footer .contact{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
 .site-footer .links{display:flex;gap:12px}
+
+@media (max-width:1024px){
+  .hero{grid-template-columns:1fr;gap:32px;padding:48px 24px}
+  .hero-art{order:-1}
+  .charts{grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+}
+
+@media (max-width:820px){
+  .site-header{flex-wrap:wrap;gap:12px;justify-content:center;text-align:center}
+  .brand{justify-content:center}
+  .nav{width:100%;display:flex;flex-wrap:wrap;justify-content:center;gap:12px}
+  .nav a{margin:0}
+  .panel{padding:28px 18px}
+  .cta-row{flex-wrap:wrap}
+}
+
+@media (max-width:640px){
+  .hero-text h2{font-size:28px}
+  .project-content{flex-direction:column;gap:12px}
+  .project-chart{width:100%;}
+  .project-chart canvas{max-width:160px}
+  .charts{grid-template-columns:1fr}
+  .grid{grid-template-columns:1fr}
+  .token{flex-direction:column;align-items:flex-start}
+  .card{padding:14px}
+  .project{padding:14px}
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,12 +4,39 @@ const donutCtx = () => document.getElementById('langDonut').getContext('2d');
 const barsCtx = () => document.getElementById('langBars').getContext('2d');
 let donutChart = null;
 let barsChart = null;
+let projectCharts = [];
+
+const brandPalette = [
+  '#8ecaff', '#5fa8ff', '#2f7bff', '#1b56d6',
+  '#f6b3c8', '#e985a8', '#d45c88', '#b63e71', '#92265a', '#5a0d21',
+  '#a8f0e4', '#6fd5c2', '#3db6a3', '#2f8c8c',
+  '#fad48b', '#f6a768', '#f07e5f', '#d95c59', '#9c62ff', '#7e4cff'
+];
 
 function palette(n){
-  const base = ['#8ecaff','#a1d4ff','#b5ddff','#c9e6ff','#dcedff','#f5f7fa','#800020','#9a0f2b','#b31b35','#cd2740','#e7334a','#5a0d21'];
   const out = [];
-  for(let i=0;i<n;i++) out.push(base[i % base.length]);
+  for(let i=0;i<n;i++) out.push(brandPalette[i % brandPalette.length]);
   return out;
+}
+
+function computeSlices(entries, total, { max=12, minShare=0.01 } = {}){
+  const labels = [];
+  const values = [];
+  let other = 0;
+  for(const [label, value] of entries){
+    const share = total ? value / total : 0;
+    if(labels.length < max || share >= minShare){
+      labels.push(label);
+      values.push(value);
+    }else{
+      other += value;
+    }
+  }
+  if(other > 0){
+    labels.push('Other');
+    values.push(other);
+  }
+  return { labels, values };
 }
 
 function renderDonut(labels, values){
@@ -25,7 +52,7 @@ function renderBars(labels, values){
   if(barsChart) barsChart.destroy();
   barsChart = new Chart(barsCtx(), {
     type: 'bar',
-    data: { labels, datasets: [{ data: values, borderWidth: 0 }] },
+    data: { labels, datasets: [{ data: values, borderWidth: 0, backgroundColor: palette(values.length), borderRadius: 6 }] },
     options: {
       indexAxis: 'y',
       scales: {
@@ -37,28 +64,73 @@ function renderBars(labels, values){
   });
 }
 
-function renderProjects(list){
+function renderProjects(list, repoLangMap){
   const grid = document.getElementById('projectGrid');
   grid.innerHTML = '';
+  projectCharts.forEach(chart => chart.destroy());
+  projectCharts = [];
   for(const r of list){
     const card = document.createElement('div');
     card.className = 'project';
     const topics = (r.topics||[]).slice(0,4).map(t=>`<span class="tag-chip">${t}</span>`).join(' ');
     const desc = r.description ? r.description : 'No description provided.';
+    const chartId = `projectChart-${r.name.replace(/[^a-z0-9]/gi,'-')}`;
     card.innerHTML = `
-      <h4><a href="${r.html_url}" target="_blank" rel="noopener">${r.name}</a></h4>
-      <p class="muted">${desc}</p>
-      <div class="tags">${topics}</div>
-      <p class="tiny muted">★ ${r.stargazers_count || 0} · Updated ${new Date(r.updated_at).toLocaleDateString()}</p>
+      <div class="project-content">
+        <div class="project-info">
+          <h4><a href="${r.html_url}" target="_blank" rel="noopener">${r.name}</a></h4>
+          <p class="muted">${desc}</p>
+          <div class="tags">${topics}</div>
+          <p class="tiny muted">★ ${r.stargazers_count || 0} · Updated ${new Date(r.updated_at).toLocaleDateString()}</p>
+        </div>
+        <div class="project-chart">
+          <canvas id="${chartId}" width="140" height="140" aria-label="Language breakdown for ${r.name}" role="img"></canvas>
+        </div>
+      </div>
     `;
     grid.appendChild(card);
+
+    const langData = repoLangMap[r.name] || r.languages || {};
+    const entries = Object.entries(langData).sort((a,b)=>b[1]-a[1]);
+    const total = entries.reduce((acc,[,v])=>acc+v,0);
+    const canvas = document.getElementById(chartId);
+
+    if(!entries.length || total === 0){
+      const chartContainer = card.querySelector('.project-chart');
+      chartContainer.innerHTML = '<p class="tiny muted">No language data</p>';
+      continue;
+    }
+
+    const { labels, values } = computeSlices(entries, total, { max:6, minShare:0.03 });
+
+    const chart = new Chart(canvas.getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels,
+        datasets: [{
+          data: values,
+          borderWidth: 0,
+          backgroundColor: palette(values.length),
+        }]
+      },
+      options: {
+        cutout: '60%',
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: { color: '#e7edf3', boxWidth: 10, font: { size: 10 } }
+          }
+        }
+      }
+    });
+    projectCharts.push(chart);
   }
 }
 
 function setStats(repoCount, topLanguage, stars){
   document.getElementById('repoCount').textContent = repoCount;
   document.getElementById('topLang').textContent = topLanguage || '—';
-  document.getElementById('stars').textContent = stars;
+  document.getElementById('stars').textContent = Number(stars || 0).toLocaleString();
   document.getElementById('year').textContent = new Date().getFullYear();
 }
 
@@ -78,21 +150,19 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   try{
-    const { repos, topStarred, aggregate, stars } = await aggregateLanguages();
+    const { repos, topStarred, aggregate, repoLangs, stars } = await aggregateLanguages();
     const sorted = sortLangs(aggregate);
     if(sorted.length === 0){
       showError('No language data found. Add a token or check if repos are public.');
       return;
     }
 
-    const labels = sorted.slice(0,8).map(([k])=>k);
-    const values = sorted.slice(0,8).map(([,v])=>v);
-    const others = sorted.slice(8).reduce((a,[,v])=>a+v,0);
-    if(others>0){ labels.push('Other'); values.push(others); }
+    const total = sorted.reduce((a,[,v])=>a+v,0);
+    const { labels, values } = computeSlices(sorted, total, { max:16, minShare:0.005 });
 
     renderDonut(labels, values);
     renderBars(labels, values.map(v=>Math.round(v/1024)));
-    renderProjects(topStarred);
+    renderProjects(topStarred, repoLangs);
     setStats(repos.length, labels[0], stars);
 
   }catch(err){


### PR DESCRIPTION
## Summary
- expand the chart palette with brand-consistent colors and reusable slice helpers
- surface smaller languages in charts while keeping per-project doughnut legends tidy
- exclude the VB-Custom repository from fetched projects and aggregated GitHub statistics

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e14e67cedc83219c589d7b28c93f20